### PR TITLE
🔧 議事録データ統合とAboutページ修正

### DIFF
--- a/frontend/components/AboutPage.tsx
+++ b/frontend/components/AboutPage.tsx
@@ -204,7 +204,7 @@ export default function AboutPage() {
           </div>
           <div className="flex items-center gap-4 pt-4">
             <a
-              href="https://github.com/hironeko/new-jp-search"
+              href="https://github.com/open-politicians-jp/gijiroku-search"
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center gap-2 px-4 py-2 bg-gray-900 text-white rounded-lg hover:bg-gray-800 transition-colors text-sm"


### PR DESCRIPTION
## Summary
- 議事録データの読み込み問題を解決（17件→約39,593件）
- data-loader.tsで全データファイルを統合読み込みするように修正
- AboutページのGitHubリンクを正しいリポジトリに更新

## 問題解決
### 議事録データ統合
- `speeches_latest.json`（17件）のみ読み込んでいた問題を修正
- 全データファイル（speeches_2025_*.json）を統合して読み込み
- 重複除去とソート機能を追加
- 実際のデータ量（約39,593件）が統計に正しく反映されるように修正

### AboutページGitHubリンク修正
- 古いリポジトリURL（hironeko/new-jp-search）を削除
- 正しいリポジトリURL（open-politicians-jp/gijiroku-search）に更新

## Test plan
- [ ] ローカルで統計ページを確認し、約39,593件のデータが表示されることを確認
- [ ] 検索機能が全データファイルから検索できることを確認
- [ ] AboutページのGitHubリンクが正しいリポジトリに遷移することを確認
- [ ] パフォーマンスに問題がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)