### PR TITLE
✨ Add radio button clear functionality (Issue #7)

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -119,6 +119,16 @@ export default function Home() {
     }
   };
 
+  const handleSearchTypeChange = () => {
+    setSearchResult(null);
+    setCommitteeNewsResult(null);
+    setBillsResult(null);
+    setQuestionsResult(null);
+    setAllSpeeches([]);
+    setCurrentSearchParams(null);
+    setError(null);
+  };
+
   const handlePageChange = (page: 'search' | 'stats' | 'about' | 'manifestos') => {
     setCurrentPage(page);
     setError(null);
@@ -133,7 +143,7 @@ export default function Home() {
           <div className="py-8">
             <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
               {/* 検索フォーム */}
-              <SearchForm onSearch={handleSearch} loading={loading} />
+              <SearchForm onSearch={handleSearch} onSearchTypeChange={handleSearchTypeChange} loading={loading} />
               
               {/* エラー表示 */}
               {error && (

--- a/frontend/components/SearchForm.tsx
+++ b/frontend/components/SearchForm.tsx
@@ -6,10 +6,11 @@ import { SearchParams } from '@/types';
 
 interface SearchFormProps {
   onSearch: (params: SearchParams) => void;
+  onSearchTypeChange?: () => void;
   loading?: boolean;
 }
 
-export default function SearchForm({ onSearch, loading = false }: SearchFormProps) {
+export default function SearchForm({ onSearch, onSearchTypeChange, loading = false }: SearchFormProps) {
   const [query, setQuery] = useState('');
   const [speaker, setSpeaker] = useState('');
   const [party, setParty] = useState('');
@@ -37,6 +38,11 @@ export default function SearchForm({ onSearch, loading = false }: SearchFormProp
     onSearch(params);
   };
 
+  const handleSearchTypeChange = (newSearchType: 'speeches' | 'committee_news' | 'bills' | 'questions') => {
+    setSearchType(newSearchType);
+    onSearchTypeChange?.();
+  };
+
   const handleReset = () => {
     setQuery('');
     setSpeaker('');
@@ -58,7 +64,7 @@ export default function SearchForm({ onSearch, loading = false }: SearchFormProp
               name="searchType"
               value="speeches"
               checked={searchType === 'speeches'}
-              onChange={(e) => setSearchType(e.target.value as 'speeches' | 'committee_news' | 'bills' | 'questions')}
+              onChange={(e) => handleSearchTypeChange(e.target.value as 'speeches' | 'committee_news' | 'bills' | 'questions')}
               className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 focus:ring-2"
             />
             <span className="text-sm font-medium text-gray-700">議事録</span>
@@ -69,7 +75,7 @@ export default function SearchForm({ onSearch, loading = false }: SearchFormProp
               name="searchType"
               value="committee_news"
               checked={searchType === 'committee_news'}
-              onChange={(e) => setSearchType(e.target.value as 'speeches' | 'committee_news' | 'bills' | 'questions')}
+              onChange={(e) => handleSearchTypeChange(e.target.value as 'speeches' | 'committee_news' | 'bills' | 'questions')}
               className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 focus:ring-2"
             />
             <span className="text-sm font-medium text-gray-700">委員会活動</span>
@@ -80,7 +86,7 @@ export default function SearchForm({ onSearch, loading = false }: SearchFormProp
               name="searchType"
               value="bills"
               checked={searchType === 'bills'}
-              onChange={(e) => setSearchType(e.target.value as 'speeches' | 'committee_news' | 'bills' | 'questions')}
+              onChange={(e) => handleSearchTypeChange(e.target.value as 'speeches' | 'committee_news' | 'bills' | 'questions')}
               className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 focus:ring-2"
             />
             <span className="text-sm font-medium text-gray-700">提出法案</span>
@@ -91,7 +97,7 @@ export default function SearchForm({ onSearch, loading = false }: SearchFormProp
               name="searchType"
               value="questions"
               checked={searchType === 'questions'}
-              onChange={(e) => setSearchType(e.target.value as 'speeches' | 'committee_news' | 'bills' | 'questions')}
+              onChange={(e) => handleSearchTypeChange(e.target.value as 'speeches' | 'committee_news' | 'bills' | 'questions')}
               className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 focus:ring-2"
             />
             <span className="text-sm font-medium text-gray-700">質問主意書</span>


### PR DESCRIPTION
## Summary
- Implement radio button clear functionality when search type changes
- Clear search results when switching between 議事録/委員会活動/提出法案/質問主意書
- Add callback mechanism to clear stale results

## Changes
- **SearchForm.tsx**: Add `onSearchTypeChange` callback prop and handler function
- **page.tsx**: Implement result clearing logic when search type changes

## Test plan
- [ ] Switch between different search types (議事録 → 委員会活動 → 提出法案 → 質問主意書)
- [ ] Verify that previous search results are cleared immediately
- [ ] Confirm no TypeScript errors or build issues
- [ ] Test that search functionality still works correctly after switching

## Fixes
Closes #7

🤖 Generated with [Claude Code](https://claude.ai/code)