### PR TITLE
fix: GitHub Actionsワークフローのsed構文エラーを修正 (v2)

### DIFF
--- a/.github/workflows/release-tag-deploy.yml
+++ b/.github/workflows/release-tag-deploy.yml
@@ -223,14 +223,7 @@ $COMMITS
         DATE=$(date '+%Y-%m-%d')
         
         # Add release entry to CLAUDE.md
-        sed -i "/## 開発ガイドライン/i\\
-## 最新リリース情報\\
-\\
-- **バージョン**: $NEW_VERSION\\
-- **リリース日**: $DATE\\
-- **主な変更**: GitHub Actions自動リリース対応\\
-\\
-" CLAUDE.md
+        sed -i "/## 開発ガイドライン/i\\## 最新リリース情報\n\n- **バージョン**: $NEW_VERSION\n- **リリース日**: $DATE\n- **主な変更**: GitHub Actions自動リリース対応\n" CLAUDE.md
         
         echo "✅ CLAUDE.md updated with release $NEW_VERSION"
         


### PR DESCRIPTION
## Summary  
GitHub Actionsワークフローファイルのsed構文エラーを修正（最新mainから再作成）

## 問題
`.github/workflows/release-tag-deploy.yml` でYAML構文エラーが発生
- sedコマンドの複数行改行エスケープが不正
- GitHub Actionsパーサーがワークフローファイルを読み込めない

## 修正内容
- sedコマンドの複数行構文を1行に統合
- YAML構文エラーを解決

## 変更詳細
```bash
# 修正前（複数行でエスケープエラー）
sed -i "/## 開発ガイドライン/i\\
## 最新リリース情報\\
\\
- **バージョン**: $NEW_VERSION\\
...

# 修正後（1行で正しいエスケープ）
sed -i "/## 開発ガイドライン/i\\## 最新リリース情報\n\n- **バージョン**: $NEW_VERSION\n..." CLAUDE.md
```

## Test plan
- [x] 最新origin/mainから派生（コンフリクト解決）
- [x] ワークフローファイルの構文確認
- [x] GitHub ActionsでのYAMLパース確認
- [ ] 修正後のワークフロー実行確認

## 今後の改善点
- ブランチ作成時は必ず `git reset --hard origin/main` でorigin/mainから確実に派生

🤖 Generated with [Claude Code](https://claude.ai/code)