### PR TITLE
fix: Static export compatibility for GitHub Actions deployment

### DIFF
--- a/frontend/app/summaries/page.tsx
+++ b/frontend/app/summaries/page.tsx
@@ -1,32 +1,76 @@
-import { Metadata } from 'next';
-import { SummariesLoader } from '@/lib/summaries-loader';
+'use client';
+
+import React, { useState, useEffect } from 'react';
 import SummariesPage from '@/components/SummariesPage';
 import Header from '@/components/Header';
+import { SummariesClientLoader } from '@/lib/summaries-client-loader';
+import { MeetingSummary } from '@/types';
 
-export const metadata: Metadata = {
-  title: '議会要約検索 (Beta) | 日本政治議事録横断検索',
-  description: 'AI技術を活用した国会議事録の議会単位要約システム。重要な議論と決定事項を効率的に把握できます。',
-  keywords: ['国会', '議事録', '要約', 'AI', '政治', '法案', '審議'],
-};
+export default function SummariesPageWrapper() {
+  const [initialSummaries, setInitialSummaries] = useState<MeetingSummary[]>([]);
+  const [houses, setHouses] = useState<string[]>([]);
+  const [committees, setCommittees] = useState<string[]>([]);
+  const [keywords, setKeywords] = useState<string[]>([]);
+  const [stats, setStats] = useState<{
+    total_summaries: number;
+    total_meetings: number;
+    houses: string[];
+    committees: string[];
+    keywords: string[];
+    date_range: { from: string; to: string };
+  }>({
+    total_summaries: 0,
+    total_meetings: 0,
+    houses: [],
+    committees: [],
+    keywords: [],
+    date_range: { from: '', to: '' }
+  });
+  const [isLoading, setIsLoading] = useState(true);
 
-export default async function SummariesPageWrapper() {
-  const loader = new SummariesLoader();
-  
-  // 初期データ読み込み
-  const [initialResult, houses, committees, keywords, stats] = await Promise.all([
-    loader.searchSummaries({ limit: 10, offset: 0 }),
-    loader.getAvailableHouses(),
-    loader.getAvailableCommittees(),
-    loader.getAvailableKeywords(),
-    loader.getSummaryStats()
-  ]);
+  useEffect(() => {
+    const loadInitialData = async () => {
+      try {
+        const [summariesResult, housesData, committeesData, keywordsData, statsData] = await Promise.all([
+          SummariesClientLoader.searchSummaries({ limit: 10, offset: 0 }),
+          SummariesClientLoader.getAvailableHouses(),
+          SummariesClientLoader.getAvailableCommittees(),
+          SummariesClientLoader.getAvailableKeywords(),
+          SummariesClientLoader.getSummaryStats()
+        ]);
+
+        setInitialSummaries(summariesResult.summaries);
+        setHouses(housesData);
+        setCommittees(committeesData);
+        setKeywords(keywordsData);
+        setStats(statsData);
+      } catch (error) {
+        console.error('Error loading initial data:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadInitialData();
+  }, []);
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="text-center">
+          <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mb-4"></div>
+          <p className="text-gray-600">議会要約データを読み込み中...</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-gray-50">
       <Header currentPage="summaries" />
       <main>
         <SummariesPage
-          initialSummaries={initialResult.summaries}
+          initialSummaries={initialSummaries}
           houses={houses}
           committees={committees}
           keywords={keywords}

--- a/frontend/components/SummariesPage.tsx
+++ b/frontend/components/SummariesPage.tsx
@@ -218,20 +218,11 @@ const SummariesPage: React.FC<SummariesPageProps> = ({
   const handleSearch = async (newParams: SummarySearchParams) => {
     setIsLoading(true);
     try {
-      const response = await fetch('/api/summaries?' + new URLSearchParams(
-        Object.entries(newParams).reduce((acc, [key, value]) => {
-          if (value !== undefined && value !== '') {
-            acc[key] = Array.isArray(value) ? value.join(',') : String(value);
-          }
-          return acc;
-        }, {} as Record<string, string>)
-      ));
-      
-      if (response.ok) {
-        const result = await response.json();
-        setSummaries(result.summaries);
-        setSearchParams(newParams);
-      }
+      // 静的エクスポート対応: クライアントサイドローダーを使用
+      const { SummariesClientLoader } = await import('@/lib/summaries-client-loader');
+      const result = await SummariesClientLoader.searchSummaries(newParams);
+      setSummaries(result.summaries);
+      setSearchParams(newParams);
     } catch (error) {
       console.error('検索エラー:', error);
     } finally {

--- a/frontend/lib/summaries-client-loader.ts
+++ b/frontend/lib/summaries-client-loader.ts
@@ -1,0 +1,241 @@
+import { MeetingSummary, SummarySearchParams, SummariesResult } from '@/types';
+
+/**
+ * 議会要約クライアントサイドローダー（静的エクスポート対応）
+ */
+export class SummariesClientLoader {
+  private static cache: Map<string, { data: MeetingSummary[], timestamp: number }> = new Map();
+  private static readonly CACHE_TTL = 5 * 60 * 1000; // 5分間キャッシュ
+
+  /**
+   * キャッシュの有効性をチェック
+   */
+  private static isCacheValid(timestamp: number): boolean {
+    return Date.now() - timestamp < this.CACHE_TTL;
+  }
+
+  /**
+   * 単一の要約ファイルを読み込み
+   */
+  private static async loadSummaryFile(fileName: string): Promise<MeetingSummary | null> {
+    try {
+      const response = await fetch(`/data/summaries/${fileName}`);
+      if (!response.ok) {
+        console.warn(`Failed to load summary file: ${fileName}`);
+        return null;
+      }
+      
+      const summary: MeetingSummary = await response.json();
+      
+      // データ品質チェック
+      if (!summary.meeting_info?.date || !summary.meeting_info?.house || !summary.meeting_info?.committee) {
+        console.warn(`Invalid summary data in ${fileName}`);
+        return null;
+      }
+      
+      return summary;
+    } catch (error) {
+      console.error(`Error loading summary file ${fileName}:`, error);
+      return null;
+    }
+  }
+
+  /**
+   * 利用可能な要約ファイル一覧を取得（静的リスト）
+   */
+  private static getSummaryFileNames(): string[] {
+    return [
+      'summary_20250603_衆議_議院運営委員会.json',
+      'summary_20250530_衆議_議院運営委員会.json',
+      'summary_20250530_参議_議院運営委員会.json',
+      'summary_20250528_参議_議院運営委員会.json',
+      'summary_20250527_衆議_議院運営委員会.json',
+      'summary_20250523_衆議_予算委員会.json',
+      'summary_20250523_参議_議院運営委員会.json',
+      'summary_20250522_衆議_議院運営委員会.json',
+      'summary_20241009_衆議_本会議.json',
+      'summary_20241009_衆議_議院運営委員会.json',
+      'summary_20241009_参議_本会議.json'
+    ];
+  }
+
+  /**
+   * 全ての要約ファイルを読み込み（クライアントサイド）
+   */
+  static async loadAllSummaries(): Promise<MeetingSummary[]> {
+    try {
+      // キャッシュチェック
+      const cacheKey = 'all_summaries_client';
+      const cached = this.cache.get(cacheKey);
+      
+      if (cached && this.isCacheValid(cached.timestamp)) {
+        return cached.data;
+      }
+      
+      const fileNames = this.getSummaryFileNames();
+
+      // 並列処理で高速化
+      const summaryPromises = fileNames.map(fileName => this.loadSummaryFile(fileName));
+      const loadedSummaries = await Promise.all(summaryPromises);
+      
+      // null値を除外
+      const summaries = loadedSummaries.filter((summary): summary is MeetingSummary => 
+        summary !== null
+      );
+
+      // 日付順にソート（新しい順）
+      summaries.sort((a, b) => 
+        new Date(b.meeting_info.date).getTime() - new Date(a.meeting_info.date).getTime()
+      );
+
+      // キャッシュに保存
+      this.cache.set(cacheKey, {
+        data: summaries,
+        timestamp: Date.now()
+      });
+
+      return summaries;
+    } catch (error) {
+      console.error('Error loading summaries:', error);
+      return [];
+    }
+  }
+
+  /**
+   * 要約検索（クライアントサイド）
+   */
+  static async searchSummaries(params: SummarySearchParams): Promise<SummariesResult> {
+    const allSummaries = await this.loadAllSummaries();
+    let filteredSummaries = allSummaries;
+
+    // テキスト検索
+    if (params.q && params.q.trim()) {
+      const query = params.q.toLowerCase();
+      filteredSummaries = filteredSummaries.filter(summary => 
+        summary.summary.text.toLowerCase().includes(query) ||
+        summary.meeting_info.committee.toLowerCase().includes(query) ||
+        summary.summary.keywords.some(keyword => 
+          keyword.toLowerCase().includes(query)
+        )
+      );
+    }
+
+    // 院でフィルター
+    if (params.house) {
+      filteredSummaries = filteredSummaries.filter(summary =>
+        summary.meeting_info.house === params.house
+      );
+    }
+
+    // 委員会でフィルター
+    if (params.committee) {
+      filteredSummaries = filteredSummaries.filter(summary =>
+        summary.meeting_info.committee.includes(params.committee!)
+      );
+    }
+
+    // 日付範囲でフィルター
+    if (params.date_from) {
+      filteredSummaries = filteredSummaries.filter(summary =>
+        summary.meeting_info.date >= params.date_from!
+      );
+    }
+
+    if (params.date_to) {
+      filteredSummaries = filteredSummaries.filter(summary =>
+        summary.meeting_info.date <= params.date_to!
+      );
+    }
+
+    // キーワードでフィルター
+    if (params.keywords && params.keywords.length > 0) {
+      filteredSummaries = filteredSummaries.filter(summary =>
+        params.keywords!.some(keyword =>
+          summary.summary.keywords.includes(keyword)
+        )
+      );
+    }
+
+    // ページネーション
+    const limit = params.limit || 10;
+    const offset = params.offset || 0;
+    const total = filteredSummaries.length;
+    const paginatedSummaries = filteredSummaries.slice(offset, offset + limit);
+
+    return {
+      summaries: paginatedSummaries,
+      total,
+      limit,
+      offset,
+      has_more: offset + limit < total
+    };
+  }
+
+  /**
+   * 利用可能な院の一覧を取得
+   */
+  static async getAvailableHouses(): Promise<string[]> {
+    const summaries = await this.loadAllSummaries();
+    const houses = new Set(summaries.map(s => s.meeting_info.house));
+    return Array.from(houses).sort();
+  }
+
+  /**
+   * 利用可能な委員会の一覧を取得
+   */
+  static async getAvailableCommittees(): Promise<string[]> {
+    const summaries = await this.loadAllSummaries();
+    const committees = new Set(summaries.map(s => s.meeting_info.committee));
+    return Array.from(committees).sort();
+  }
+
+  /**
+   * 利用可能なキーワードの一覧を取得
+   */
+  static async getAvailableKeywords(): Promise<string[]> {
+    const summaries = await this.loadAllSummaries();
+    const keywords = new Set<string>();
+    
+    summaries.forEach(summary => {
+      summary.summary.keywords.forEach(keyword => keywords.add(keyword));
+    });
+
+    return Array.from(keywords).sort();
+  }
+
+  /**
+   * 統計情報を取得
+   */
+  static async getSummaryStats() {
+    const summaries = await this.loadAllSummaries();
+    
+    if (summaries.length === 0) {
+      return {
+        total_summaries: 0,
+        total_meetings: 0,
+        houses: [],
+        committees: [],
+        keywords: [],
+        date_range: { from: '', to: '' }
+      };
+    }
+
+    const houses = await this.getAvailableHouses();
+    const committees = await this.getAvailableCommittees();
+    const keywords = await this.getAvailableKeywords();
+
+    const dates = summaries.map(s => s.meeting_info.date).sort();
+
+    return {
+      total_summaries: summaries.length,
+      total_meetings: summaries.length,
+      houses,
+      committees,
+      keywords: keywords.slice(0, 20),
+      date_range: {
+        from: dates[0],
+        to: dates[dates.length - 1]
+      }
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- 議会要約システムの静的エクスポート対応でGitHub Actions deployment修正
- Next.js API Routes削除してクライアントサイドローダー実装
- SSR→CSR変換で`output: export`制限を回避

## Changes
- **lib/summaries-client-loader.ts**: 新規作成 - 静的エクスポート対応のクライアント専用ローダー
- **app/summaries/page.tsx**: SSR→CSR変換、useEffectでデータ読み込み
- **components/SummariesPage.tsx**: 検索API呼び出しをクライアントローダーに変更

## Technical Details
- **Issue**: `export const dynamic = "force-dynamic"` が `output: export` と非互換
- **Solution**: API Routes完全削除、クライアントサイドでJSONファイル直接読み込み
- **Performance**: 並列処理とキャッシュ機能で高速化
- **Compatibility**: 11件の要約ファイルをハードコーディングで対応

## Test Plan
- [x] ローカル開発環境で動作確認済み
- [x] 議会要約検索・フィルタリング機能正常動作
- [x] モバイルレスポンシブ対応確認済み
- [ ] GitHub Actions deployment test 必要

🤖 Generated with [Claude Code](https://claude.ai/code)