### PR TITLE
fix: Add missing Header component to legislators page

### DIFF
--- a/frontend/app/legislators/page.tsx
+++ b/frontend/app/legislators/page.tsx
@@ -6,6 +6,7 @@ import { Legislator, LegislatorFilter, LegislatorsData } from '@/types/legislato
 import { legislatorsLoader } from '@/lib/legislators-loader';
 import LegislatorsFilter from '@/components/LegislatorsFilter';
 import LegislatorsList from '@/components/LegislatorsList';
+import Header from '@/components/Header';
 
 export default function LegislatorsPage() {
   const [legislatorsData, setLegislatorsData] = useState<LegislatorsData | null>(null);
@@ -54,8 +55,10 @@ export default function LegislatorsPage() {
   };
 
   return (
-    <div className="py-8">
-      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div className="min-h-screen bg-gray-50">
+      <Header currentPage="legislators" />
+      <main className="py-8">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* ヘッダー */}
         <div className="mb-8">
           <div className="flex items-center mb-4">
@@ -109,7 +112,8 @@ export default function LegislatorsPage() {
           legislators={filteredLegislators}
           isLoading={isLoading}
         />
-      </div>
+        </div>
+      </main>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- 議員一覧ページに消えていたHeaderコンポーネントを追加
- ナビゲーションメニューとハンバーガーメニューが正常に表示されるよう修正

## Changes
- **app/legislators/page.tsx**: Headerコンポーネントのimportと表示を追加
- レイアウト統一のため`min-h-screen bg-gray-50`クラス追加
- `main`タグで適切なページ構造に修正

## Test Plan
- [x] 議員一覧ページでヘッダーナビゲーション表示確認
- [x] モバイル環境でハンバーガーメニュー動作確認
- [x] 他のページとのレイアウト統一性確認

🤖 Generated with [Claude Code](https://claude.ai/code)