### PR TITLE
hotfix: Remove console.log statements causing deployment failure

### DIFF
--- a/frontend/lib/data-loader.ts
+++ b/frontend/lib/data-loader.ts
@@ -63,7 +63,7 @@ class StaticDataLoader {
       const indexData = await indexResponse.json();
       const totalChunks = indexData.metadata.total_chunks;
       
-      console.log(`Loading ${totalChunks} speech chunks...`);
+      // Loading speech chunks
       
       // 全チャンクを並列読み込み
       const chunkPromises = [];
@@ -85,7 +85,7 @@ class StaticDataLoader {
         }
       }
       
-      console.log(`Loaded ${allSpeeches.length} speeches from ${totalChunks} chunks`);
+      // Speeches loaded from chunks
       return allSpeeches;
       
     } catch (error) {
@@ -107,7 +107,7 @@ class StaticDataLoader {
       }
       
       const data = await response.json();
-      console.log(`Loaded ${data.data?.length || 0} speeches from latest.json`);
+      // Speeches loaded from latest.json
       return data.data || [];
       
     } catch (error) {
@@ -173,7 +173,7 @@ class StaticDataLoader {
     }
 
     try {
-      console.log('Loading speeches data...');
+      // Loading speeches data
       
       // 分割データから読み込み（優先）
       const allSpeeches = await this.loadSpeechesFromChunks();


### PR DESCRIPTION
## Critical Hotfix
PR #65のマージ後にGitHub Actions deploymentが失敗している問題の緊急修正

## Root Cause
- **失敗したデプロイ**: https://github.com/open-politicians-jp/gijiroku-search/actions/runs/15811436621
- **ESLint no-console違反**: マージ時にconsole.log文が残存
- **ビルド失敗**: 本番ビルドでESLintエラー発生

## Changes
- **lib/data-loader.ts**: 4つのconsole.log文をコメントに変更
- console.error は保持（エラー報告用）
- ESLint no-console rule準拠

## Verification
- ✅ ローカルビルドテスト成功
- ✅ ESLintエラー解消確認
- ✅ 静的エクスポート生成確認

## Impact
この修正により：
- GitHub Actions deployment復旧
- 本番環境への47,888件データ反映
- 議会要約ページ・ハンバーガーメニュー復旧

## Priority: URGENT
本番環境の機能復旧のため緊急マージ必要

🤖 Generated with [Claude Code](https://claude.ai/code)