### PR TITLE
Fix: データ収集重複問題と品質改善

### DIFF
--- a/scripts/uv-data-collection/collect_committee_news_fixed.py
+++ b/scripts/uv-data-collection/collect_committee_news_fixed.py
@@ -297,10 +297,44 @@ class CommitteeNewsCollector:
         if not text:
             return ""
         
+        # JavaScript無効メッセージの除去
+        js_messages = [
+            'ブラウザのJavaScriptが無効のため、サイト内検索はご利用いただけません。',
+            'JavaScriptが無効です',
+            'JavaScript を有効にしてください',
+            'JavaScriptを有効にしてください',
+            'ブラウザのJavaScriptが無効のため',
+            'サイト内検索はご利用いただけません'
+        ]
+        
+        for msg in js_messages:
+            text = text.replace(msg, '')
+        
+        # ナビゲーション・フッター等の不要な定型文除去
+        unwanted_phrases = [
+            'ホーム',
+            'サイトマップ',
+            'プライバシーポリシー',
+            'ご利用案内',
+            '国会に関するお問い合わせ',
+            '文字サイズ変更',
+            'Foreign Language',
+            'トップページ',
+            'ページの先頭',
+            'ページトップへ戻る'
+        ]
+        
+        for phrase in unwanted_phrases:
+            text = text.replace(phrase, '')
+        
         # 改行・スペースの正規化
         text = re.sub(r'\n\s*\n', '\n\n', text)  # 連続空行を2行まで
         text = re.sub(r'[ \t]+', ' ', text)  # 連続スペースを1つに
         text = re.sub(r'[\u3000]+', ' ', text)  # 全角スペースを半角に
+        
+        # 空の行を除去
+        lines = [line.strip() for line in text.split('\n') if line.strip()]
+        text = '\n'.join(lines)
         
         return text.strip()
     


### PR DESCRIPTION
## Summary
- 🔄 質問主意書・法案データの重複収集問題を解決
- 🧹 委員会ニュースのJavaScript無効メッセージ除去
- 📅 日付範囲指定での増分収集機能実装
- 🔧 GitHub Actions ワークフローの再有効化

## 解決された問題

### 1. 質問主意書の重複収集問題
- **問題**: 毎回同じデータを収集し続けていた
- **解決**: 既存データとの重複チェック機能を追加
- **改善**: 過去30日分のみを増分収集するよう変更

### 2. 委員会ニュースの品質問題  
- **問題**: "JavaScriptを有効化してください"等の不要な文言が混入
- **解決**: 自動的にJavaScript関連メッセージとナビゲーション文言を除去
- **改善**: 実際のニュース内容のみが抽出されるよう品質向上

### 3. 法案データ収集の停止
- **問題**: GitHub Actionsで法案収集がコメントアウトされていた
- **解決**: 日次自動収集ワークフローで再有効化
- **改善**: 定期的な法案データ更新の再開

## 技術的改善

### 増分収集システム
```bash
# 過去30日分のみ収集
uv run python collect_questions_fixed.py --days 30

# 特定期間を指定
uv run python collect_questions_fixed.py --start-date 2025-06-01 --end-date 2025-06-23
```

### 重複チェック機能
- 既存の `questions_latest.json` から質問番号を読み込み
- 新規データのみを収集対象とする
- データ品質チェックによる無効データ除外

### データクリーニング強化
- JavaScript無効メッセージの自動除去
- ナビゲーション・フッター文言の除去
- 空行・不要スペースの正規化

## Test plan
- [ ] **質問主意書収集テスト**: 重複チェック機能の動作確認
- [ ] **委員会ニュースの品質確認**: JavaScript文言が除去されているか確認
- [ ] **法案収集の動作確認**: GitHub Actionsで正常に収集されるか確認
- [ ] **増分収集の確認**: 新しいデータのみが収集されることを確認
- [ ] **フロントエンド表示確認**: クリーンなデータが正常に表示されるか確認

これにより、データ収集の効率性とデータ品質が大幅に向上し、ユーザー体験の改善につながります。

🤖 Generated with [Claude Code](https://claude.ai/code)