### PR TITLE
Fix navigation routing issues between pages

### DIFF
--- a/frontend/app/legislators/page.tsx
+++ b/frontend/app/legislators/page.tsx
@@ -7,8 +7,10 @@ import { legislatorsLoader } from '@/lib/legislators-loader';
 import LegislatorsFilter from '@/components/LegislatorsFilter';
 import LegislatorsList from '@/components/LegislatorsList';
 import Header from '@/components/Header';
+import { useRouter } from 'next/navigation';
 
 export default function LegislatorsPage() {
+  const router = useRouter();
   const [legislatorsData, setLegislatorsData] = useState<LegislatorsData | null>(null);
   const [filteredLegislators, setFilteredLegislators] = useState<Legislator[]>([]);
   const [filter, setFilter] = useState<LegislatorFilter>({
@@ -54,9 +56,24 @@ export default function LegislatorsPage() {
     setFilter(newFilter);
   };
 
+  const handlePageChange = (page: 'search' | 'stats' | 'about' | 'manifestos' | 'legislators') => {
+    if (page === 'search') {
+      router.push('/');
+    } else if (page === 'manifestos') {
+      router.push('/#manifestos');
+    } else if (page === 'stats') {
+      router.push('/#stats');
+    } else if (page === 'about') {
+      router.push('/#about');
+    } else if (page === 'legislators') {
+      // 現在のページなので何もしない
+      return;
+    }
+  };
+
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header currentPage="legislators" />
+      <Header currentPage="legislators" onPageChange={handlePageChange} />
       <main className="py-8">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* ヘッダー */}

--- a/frontend/app/summaries/page.tsx
+++ b/frontend/app/summaries/page.tsx
@@ -6,6 +6,7 @@ import SummariesPage from '@/components/SummariesPage';
 import Header from '@/components/Header';
 import { SummariesClientLoader } from '@/lib/summaries-client-loader';
 import { MeetingSummary } from '@/types';
+import { useRouter } from 'next/navigation';
 
 // 静的エクスポート対応のため、メタデータを外部に移動
 const metadata = {
@@ -15,6 +16,7 @@ const metadata = {
 };
 
 export default function SummariesPageWrapper() {
+  const router = useRouter();
   const [initialSummaries, setInitialSummaries] = useState<MeetingSummary[]>([]);
   const [houses, setHouses] = useState<string[]>([]);
   const [committees, setCommittees] = useState<string[]>([]);
@@ -95,9 +97,24 @@ export default function SummariesPageWrapper() {
     );
   }
 
+  const handlePageChange = (page: 'search' | 'stats' | 'about' | 'manifestos' | 'legislators') => {
+    if (page === 'search') {
+      router.push('/');
+    } else if (page === 'manifestos') {
+      router.push('/#manifestos');
+    } else if (page === 'stats') {
+      router.push('/#stats');
+    } else if (page === 'about') {
+      router.push('/#about');
+    } else if (page === 'legislators') {
+      router.push('/legislators');
+    }
+    // summaries の場合は現在のページなので何もしない
+  };
+
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header currentPage="summaries" />
+      <Header currentPage="summaries" onPageChange={handlePageChange} />
       <main>
         <SummariesPage
           initialSummaries={initialSummaries}

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -13,10 +13,10 @@ export default function Header({ currentPage = 'search', onPageChange }: HeaderP
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
   const navigationItems = [
-    { key: 'search', icon: Search, label: '検索', href: '/', onClick: () => onPageChange?.('search') },
+    { key: 'search', icon: Search, label: '検索', href: '/' },
     { key: 'summaries', icon: Bot, label: '議会要約', href: '/summaries', badge: 'Beta' },
     { key: 'manifestos', icon: FileText, label: 'マニフェスト', onClick: () => onPageChange?.('manifestos') },
-    { key: 'legislators', icon: Users, label: '議員一覧', href: '/legislators', onClick: () => onPageChange?.('legislators') },
+    { key: 'legislators', icon: Users, label: '議員一覧', href: '/legislators' },
     { key: 'stats', icon: BarChart3, label: '統計', onClick: () => onPageChange?.('stats') },
     { key: 'about', icon: Info, label: 'About', onClick: () => onPageChange?.('about') }
   ];

--- a/frontend/public/data/committee_news/committee_news_test_20250624_070844.json
+++ b/frontend/public/data/committee_news/committee_news_test_20250624_070844.json
@@ -1,0 +1,74 @@
+[
+  {
+    "title": "【内閣委員会】        独立行政法人男女共同参画機構法案",
+    "url": "https://www.shugiin.go.jp/internet/itdb_rchome.nsf/html/rchome/News/naikaku21720250606026_m.htm",
+    "committee": "内閣委員会",
+    "date": "2025-06-06",
+    "news_type": "法案審議",
+    "content": "議案名:         独立行政法人男女共同参画機構法案\n委員会: 内閣委員会\n開催日: 2025-06-06\n議案キーワード: 法律案\nデータソース: page_content\n関連資料:\n- 第217回国会6月6日内閣委員会ニュース (https://www.shugiin.go.jp/internet/itdb_rchome.nsf/html/rchome/News/Honbun/naikaku21720250606026.pdf/$File/naikaku21720250606026.pdf)",
+    "content_length": 352,
+    "collected_at": "2025-06-24T07:08:42.768608",
+    "year": 2025,
+    "week": 26,
+    "source": "committee_news",
+    "bill_info": {
+      "bill_title": "        独立行政法人男女共同参画機構法案",
+      "bill_number": "内閣提出第52号",
+      "bill_keyword": "法律案",
+      "bill_source": "page_content"
+    },
+    "pdf_info": {
+      "pdf_url": "https://www.shugiin.go.jp/internet/itdb_rchome.nsf/html/rchome/News/Honbun/naikaku21720250606026.pdf/$File/naikaku21720250606026.pdf",
+      "pdf_title": "第217回国会6月6日内閣委員会ニュース",
+      "original_href": "./Honbun/naikaku21720250606026.pdf/$File/naikaku21720250606026.pdf"
+    }
+  },
+  {
+    "title": "【内閣委員会】        海洋再生可能エネルギー発電設備の整備に係る海域の利用の促進に関する法律の一部を改正する法律案",
+    "url": "https://www.shugiin.go.jp/internet/itdb_rchome.nsf/html/rchome/News/naikaku21720250530025_m.htm",
+    "committee": "内閣委員会",
+    "date": "2025-05-30",
+    "news_type": "法案審議",
+    "content": "議案名:         海洋再生可能エネルギー発電設備の整備に係る海域の利用の促進に関する法律の一部を改正する法律案\n委員会: 内閣委員会\n開催日: 2025-05-30\n議案キーワード: 法律案\nデータソース: page_content\n関連資料:\n- 第217回国会5月30日内閣委員会ニュース (https://www.shugiin.go.jp/internet/itdb_rchome.nsf/html/rchome/News/Honbun/naikaku21720250530025.pdf/$File/naikaku21720250530025.pdf)",
+    "content_length": 413,
+    "collected_at": "2025-06-24T07:08:43.804925",
+    "year": 2025,
+    "week": 26,
+    "source": "committee_news",
+    "bill_info": {
+      "bill_title": "        海洋再生可能エネルギー発電設備の整備に係る海域の利用の促進に関する法律の一部を改正する法律案",
+      "bill_number": "内閣提出第46号",
+      "bill_keyword": "法律案",
+      "bill_source": "page_content"
+    },
+    "pdf_info": {
+      "pdf_url": "https://www.shugiin.go.jp/internet/itdb_rchome.nsf/html/rchome/News/Honbun/naikaku21720250530025.pdf/$File/naikaku21720250530025.pdf",
+      "pdf_title": "第217回国会5月30日内閣委員会ニュース",
+      "original_href": "./Honbun/naikaku21720250530025.pdf/$File/naikaku21720250530025.pdf"
+    }
+  },
+  {
+    "title": "【内閣委員会】        海洋再生可能エネルギー発電設備の整備に係る海域の利用の促進に関する法律の一部を改正する法律案",
+    "url": "https://www.shugiin.go.jp/internet/itdb_rchome.nsf/html/rchome/News/naikaku21720250528024_m.htm",
+    "committee": "内閣委員会",
+    "date": "2025-05-28",
+    "news_type": "法案審議",
+    "content": "議案名:         海洋再生可能エネルギー発電設備の整備に係る海域の利用の促進に関する法律の一部を改正する法律案\n委員会: 内閣委員会\n開催日: 2025-05-28\n議案キーワード: 法律案\nデータソース: page_content\n関連資料:\n- 第217回国会5月28日内閣委員会ニュース (https://www.shugiin.go.jp/internet/itdb_rchome.nsf/html/rchome/News/Honbun/naikaku21720250528024.pdf/$File/naikaku21720250528024.pdf)",
+    "content_length": 344,
+    "collected_at": "2025-06-24T07:08:44.843410",
+    "year": 2025,
+    "week": 26,
+    "source": "committee_news",
+    "bill_info": {
+      "bill_title": "        海洋再生可能エネルギー発電設備の整備に係る海域の利用の促進に関する法律の一部を改正する法律案",
+      "bill_number": "内閣提出第46号",
+      "bill_keyword": "法律案",
+      "bill_source": "page_content"
+    },
+    "pdf_info": {
+      "pdf_url": "https://www.shugiin.go.jp/internet/itdb_rchome.nsf/html/rchome/News/Honbun/naikaku21720250528024.pdf/$File/naikaku21720250528024.pdf",
+      "pdf_title": "第217回国会5月28日内閣委員会ニュース",
+      "original_href": "./Honbun/naikaku21720250528024.pdf/$File/naikaku21720250528024.pdf"
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- 他のページから議事録検索ページに戻れない問題を修正
- 議事録検索 → マニフェスト → 議事録検索の遷移が機能しない問題を解決
- ナビゲーション構造を整理して一貫性のある画面遷移を実現

## Changes
- **Header.tsx**: 検索・議員一覧をLink遷移、マニフェスト・統計・AboutはonPageChangeタブ切り替えに整理
- **summaries/page.tsx**: useRouterによるページ遷移ハンドラーを追加
- **legislators/page.tsx**: useRouterによるページ遷移ハンドラーを追加

## Test plan
- [x] 議事録検索 → マニフェスト → 議事録検索の遷移をテスト
- [x] 議員一覧 → 検索 → 議員一覧の遷移をテスト
- [x] 要約ページ → 検索 → 要約ページの遷移をテスト
- [x] 全ページ間での双方向遷移を確認
- [x] ビルドテストを実行

🤖 Generated with [Claude Code](https://claude.ai/code)