### PR TITLE
refactor: マニフェストページ独立化と議事録検索UI簡潔化

### DIFF
--- a/frontend/app/manifestos/page.tsx
+++ b/frontend/app/manifestos/page.tsx
@@ -1,0 +1,203 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Manifesto } from '@/types';
+import { dataLoader } from '@/lib/data-loader';
+import { Search, FileText, Users, Calendar, ExternalLink } from 'lucide-react';
+
+export default function ManifestosPage() {
+  const [manifestos, setManifestos] = useState<Manifesto[]>([]);
+  const [filteredManifestos, setFilteredManifestos] = useState<Manifesto[]>([]);
+  const [selectedParty, setSelectedParty] = useState<string>('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // 政党リスト
+  const parties = [
+    '自由民主党',
+    '立憲民主党', 
+    '日本維新の会',
+    '公明党',
+    '日本共産党',
+    '国民民主党',
+    'れいわ新選組'
+  ];
+
+  useEffect(() => {
+    loadManifestos();
+  }, []);
+
+  useEffect(() => {
+    if (selectedParty) {
+      const filtered = manifestos.filter(manifesto => 
+        manifesto.party === selectedParty ||
+        (manifesto.party_aliases && manifesto.party_aliases.includes(selectedParty))
+      );
+      setFilteredManifestos(filtered);
+    } else {
+      setFilteredManifestos(manifestos);
+    }
+  }, [selectedParty, manifestos]);
+
+  const loadManifestos = async () => {
+    try {
+      setLoading(true);
+      const data = await dataLoader.loadManifestos();
+      setManifestos(data);
+      setFilteredManifestos(data);
+    } catch (err) {
+      console.error('マニフェスト読み込みエラー:', err);
+      setError('マニフェストデータの読み込みに失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handlePartyChange = (party: string) => {
+    setSelectedParty(party);
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gray-50">
+        <div className="container mx-auto px-4 py-8">
+          <div className="text-center py-16">
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
+            <p className="text-gray-600">マニフェストデータを読み込み中...</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-gray-50">
+        <div className="container mx-auto px-4 py-8">
+          <div className="text-center py-16">
+            <div className="text-red-500 mb-4">
+              <FileText className="h-16 w-16 mx-auto" />
+            </div>
+            <h2 className="text-2xl font-bold text-gray-900 mb-2">エラー</h2>
+            <p className="text-gray-600">{error}</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="container mx-auto px-4 py-8">
+        {/* ヘッダー */}
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-gray-900 mb-2">政党マニフェスト</h1>
+          <p className="text-gray-600">各政党の政策・公約を確認できます</p>
+        </div>
+
+        {/* 政党選択 */}
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 mb-6">
+          <div className="flex items-center mb-4">
+            <Users className="h-5 w-5 text-blue-600 mr-2" />
+            <h2 className="text-lg font-semibold text-gray-900">政党選択</h2>
+          </div>
+          
+          <div className="flex flex-wrap gap-2">
+            <button
+              onClick={() => handlePartyChange('')}
+              className={`px-4 py-2 rounded-full text-sm font-medium transition-colors ${
+                selectedParty === '' 
+                  ? 'bg-blue-600 text-white' 
+                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+              }`}
+            >
+              すべて
+            </button>
+            {parties.map((party) => (
+              <button
+                key={party}
+                onClick={() => handlePartyChange(party)}
+                className={`px-4 py-2 rounded-full text-sm font-medium transition-colors ${
+                  selectedParty === party 
+                    ? 'bg-blue-600 text-white' 
+                    : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                }`}
+              >
+                {party}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* 結果表示 */}
+        <div className="mb-4">
+          <p className="text-sm text-gray-600">
+            {selectedParty ? `${selectedParty}: ` : ''}
+            {filteredManifestos.length}件のマニフェスト
+          </p>
+        </div>
+
+        {/* マニフェスト一覧 */}
+        <div className="space-y-4">
+          {filteredManifestos.length === 0 ? (
+            <div className="text-center py-16">
+              <FileText className="h-16 w-16 text-gray-400 mx-auto mb-4" />
+              <h3 className="text-lg font-medium text-gray-900 mb-2">マニフェストが見つかりません</h3>
+              <p className="text-gray-600">選択した政党のマニフェストがありません。</p>
+            </div>
+          ) : (
+            filteredManifestos.map((manifesto, index) => (
+              <div key={index} className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+                <div className="flex items-start justify-between mb-4">
+                  <div className="flex-1">
+                    <h3 className="text-lg font-semibold text-gray-900 mb-2">
+                      {manifesto.title}
+                    </h3>
+                    <div className="flex items-center text-sm text-gray-600 space-x-4 mb-3">
+                      <span className="flex items-center">
+                        <Users className="h-4 w-4 mr-1" />
+                        {manifesto.party}
+                      </span>
+                      <span className="flex items-center">
+                        <Calendar className="h-4 w-4 mr-1" />
+                        {manifesto.year}年
+                      </span>
+                      {manifesto.category && (
+                        <span className="bg-blue-100 text-blue-800 px-2 py-1 rounded-full text-xs">
+                          {manifesto.category}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+                
+                <div className="text-gray-700 mb-4">
+                  <p className="line-clamp-3">
+                    {manifesto.content.length > 200 
+                      ? `${manifesto.content.substring(0, 200)}...` 
+                      : manifesto.content
+                    }
+                  </p>
+                </div>
+                
+                {manifesto.url && (
+                  <div className="flex justify-end">
+                    <a
+                      href={manifesto.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center text-blue-600 hover:text-blue-800 text-sm font-medium"
+                    >
+                      詳細を見る
+                      <ExternalLink className="h-4 w-4 ml-1" />
+                    </a>
+                  </div>
+                )}
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -7,21 +7,18 @@ import SearchResults from '@/components/SearchResults';
 import CommitteeNewsResults from '@/components/CommitteeNewsResults';
 import BillsResults from '@/components/BillsResults';
 import QuestionResults from '@/components/QuestionResults';
-import ManifestosResults from '@/components/ManifestosResults';
 import StatsPage from '@/components/StatsPage';
 import AboutPage from '@/components/AboutPage';
-import ManifestosPage from '@/components/ManifestosPage';
 import LegislatorsPage from './legislators/page';
-import { SearchParams, SearchResult, Stats, CommitteeNewsResult, BillsResult, QuestionsResult, ManifestosResult } from '@/types';
+import { SearchParams, SearchResult, Stats, CommitteeNewsResult, BillsResult, QuestionsResult } from '@/types';
 import { apiClient } from '@/lib/api';
 
 export default function Home() {
-  const [currentPage, setCurrentPage] = useState<'search' | 'stats' | 'about' | 'manifestos' | 'legislators'>('search');
+  const [currentPage, setCurrentPage] = useState<'search' | 'stats' | 'about' | 'legislators'>('search');
   const [searchResult, setSearchResult] = useState<SearchResult | null>(null);
   const [committeeNewsResult, setCommitteeNewsResult] = useState<CommitteeNewsResult | null>(null);
   const [billsResult, setBillsResult] = useState<BillsResult | null>(null);
   const [questionsResult, setQuestionsResult] = useState<QuestionsResult | null>(null);
-  const [manifestosResult, setManifestosResult] = useState<ManifestosResult | null>(null);
   const [allSpeeches, setAllSpeeches] = useState<any[]>([]);
   const [currentSearchParams, setCurrentSearchParams] = useState<SearchParams | null>(null);
   const [loading, setLoading] = useState(false);
@@ -55,28 +52,18 @@ export default function Home() {
         setSearchResult(null);
         setBillsResult(null);
         setQuestionsResult(null);
-        setManifestosResult(null);
         setAllSpeeches([]);
       } else if (params.search_type === 'bills') {
         setBillsResult(result);
         setSearchResult(null);
         setCommitteeNewsResult(null);
         setQuestionsResult(null);
-        setManifestosResult(null);
         setAllSpeeches([]);
       } else if (params.search_type === 'questions') {
         setQuestionsResult(result);
         setSearchResult(null);
         setCommitteeNewsResult(null);
         setBillsResult(null);
-        setManifestosResult(null);
-        setAllSpeeches([]);
-      } else if (params.search_type === 'manifestos') {
-        setManifestosResult(result);
-        setSearchResult(null);
-        setCommitteeNewsResult(null);
-        setBillsResult(null);
-        setQuestionsResult(null);
         setAllSpeeches([]);
       } else {
         // 議事録検索
@@ -84,7 +71,6 @@ export default function Home() {
         setCommitteeNewsResult(null);
         setBillsResult(null);
         setQuestionsResult(null);
-        setManifestosResult(null);
         setAllSpeeches(result.speeches);
       }
       
@@ -95,7 +81,6 @@ export default function Home() {
       setCommitteeNewsResult(null);
       setBillsResult(null);
       setQuestionsResult(null);
-      setManifestosResult(null);
       setAllSpeeches([]);
       setCurrentSearchParams(null);
     } finally {
@@ -139,13 +124,12 @@ export default function Home() {
     setCommitteeNewsResult(null);
     setBillsResult(null);
     setQuestionsResult(null);
-    setManifestosResult(null);
     setAllSpeeches([]);
     setCurrentSearchParams(null);
     setError(null);
   };
 
-  const handlePageChange = (page: 'search' | 'stats' | 'about' | 'manifestos' | 'legislators') => {
+  const handlePageChange = (page: 'search' | 'stats' | 'about' | 'legislators') => {
     setCurrentPage(page);
     setError(null);
   };
@@ -210,17 +194,9 @@ export default function Home() {
                 />
               )}
               
-              {/* マニフェスト検索結果 */}
-              {manifestosResult && (
-                <ManifestosResults
-                  manifestos={manifestosResult.manifestos}
-                  total={manifestosResult.total}
-                  loading={loading}
-                />
-              )}
               
               {/* 初期状態メッセージ */}
-              {!searchResult && !committeeNewsResult && !billsResult && !questionsResult && !manifestosResult && !loading && !error && (
+              {!searchResult && !committeeNewsResult && !billsResult && !questionsResult && !loading && !error && (
                 <div className="max-w-4xl mx-auto mt-12 text-center">
                   <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-12">
                     <h2 className="text-2xl font-bold text-gray-900 mb-4">
@@ -230,8 +206,7 @@ export default function Home() {
                       議事録検索：政策名、議員名、政党名、委員会名などで検索<br/>
                       委員会活動：最新の委員会開催情報、法案審議状況を検索<br/>
                       提出法案：法案タイトル、ステータス、提出者、審議状況を検索<br/>
-                      質問主意書：国会議員の政府への質問と答弁を検索<br/>
-                      マニフェスト：各政党の政策公約、政策方針を検索
+                      質問主意書：国会議員の政府への質問と答弁を検索
                     </p>
                     <div className="text-sm text-gray-500 space-y-2">
                       <p>検索例：</p>
@@ -249,7 +224,6 @@ export default function Home() {
           </div>
         )}
         
-        {currentPage === 'manifestos' && <ManifestosPage />}
         {currentPage === 'legislators' && <LegislatorsPage />}
         {currentPage === 'stats' && <StatsPage />}
         {currentPage === 'about' && <AboutPage />}

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -5,8 +5,8 @@ import { Search, BarChart3, Info, FileText, Users, Bot, Menu, X } from 'lucide-r
 import Link from 'next/link';
 
 interface HeaderProps {
-  currentPage?: 'search' | 'stats' | 'about' | 'manifestos' | 'legislators' | 'summaries';
-  onPageChange?: (page: 'search' | 'stats' | 'about' | 'manifestos' | 'legislators') => void;
+  currentPage?: 'search' | 'stats' | 'about' | 'legislators' | 'summaries';
+  onPageChange?: (page: 'search' | 'stats' | 'about' | 'legislators') => void;
 }
 
 export default function Header({ currentPage = 'search', onPageChange }: HeaderProps) {
@@ -15,8 +15,8 @@ export default function Header({ currentPage = 'search', onPageChange }: HeaderP
   const navigationItems = [
     { key: 'search', icon: Search, label: '検索', href: '/', onClick: () => onPageChange?.('search') },
     { key: 'summaries', icon: Bot, label: '議会要約', href: '/summaries', badge: 'Beta' },
-    { key: 'manifestos', icon: FileText, label: 'マニフェスト', onClick: () => onPageChange?.('manifestos') },
-    { key: 'legislators', icon: Users, label: '議員一覧', href: '/legislators', onClick: () => onPageChange?.('legislators') },
+    { key: 'manifestos', icon: FileText, label: 'マニフェスト', href: '/manifestos' },
+    { key: 'legislators', icon: Users, label: '議員一覧', href: '/legislators' },
     { key: 'stats', icon: BarChart3, label: '統計', onClick: () => onPageChange?.('stats') },
     { key: 'about', icon: Info, label: 'About', onClick: () => onPageChange?.('about') }
   ];

--- a/frontend/components/SearchForm.tsx
+++ b/frontend/components/SearchForm.tsx
@@ -17,7 +17,7 @@ export default function SearchForm({ onSearch, onSearchTypeChange, loading = fal
   const [committee, setCommittee] = useState('');
   const [dateFrom, setDateFrom] = useState('');
   const [dateTo, setDateTo] = useState('');
-  const [searchType, setSearchType] = useState<'speeches' | 'committee_news' | 'bills' | 'questions' | 'manifestos'>('speeches');
+  const [searchType, setSearchType] = useState<'speeches' | 'committee_news' | 'bills' | 'questions'>('speeches');
   const [showAdvanced, setShowAdvanced] = useState(false);
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -26,7 +26,7 @@ export default function SearchForm({ onSearch, onSearchTypeChange, loading = fal
     const params: SearchParams = {
       q: query.trim() || undefined,
       speaker: searchType === 'speeches' ? speaker.trim() || undefined : undefined,
-      party: (searchType === 'speeches' || searchType === 'manifestos') ? party.trim() || undefined : undefined,
+      party: searchType === 'speeches' ? party.trim() || undefined : undefined,
       committee: committee.trim() || undefined,
       date_from: dateFrom || undefined,
       date_to: dateTo || undefined,
@@ -38,7 +38,7 @@ export default function SearchForm({ onSearch, onSearchTypeChange, loading = fal
     onSearch(params);
   };
 
-  const handleSearchTypeChange = (newSearchType: 'speeches' | 'committee_news' | 'bills' | 'questions' | 'manifestos') => {
+  const handleSearchTypeChange = (newSearchType: 'speeches' | 'committee_news' | 'bills' | 'questions') => {
     setSearchType(newSearchType);
     onSearchTypeChange?.();
   };
@@ -64,7 +64,7 @@ export default function SearchForm({ onSearch, onSearchTypeChange, loading = fal
               name="searchType"
               value="speeches"
               checked={searchType === 'speeches'}
-              onChange={(e) => handleSearchTypeChange(e.target.value as 'speeches' | 'committee_news' | 'bills' | 'questions' | 'manifestos')}
+              onChange={(e) => handleSearchTypeChange(e.target.value as 'speeches' | 'committee_news' | 'bills' | 'questions')}
               className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 focus:ring-2"
             />
             <span className="text-sm font-medium text-gray-700">議事録</span>
@@ -75,7 +75,7 @@ export default function SearchForm({ onSearch, onSearchTypeChange, loading = fal
               name="searchType"
               value="committee_news"
               checked={searchType === 'committee_news'}
-              onChange={(e) => handleSearchTypeChange(e.target.value as 'speeches' | 'committee_news' | 'bills' | 'questions' | 'manifestos')}
+              onChange={(e) => handleSearchTypeChange(e.target.value as 'speeches' | 'committee_news' | 'bills' | 'questions')}
               className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 focus:ring-2"
             />
             <span className="text-sm font-medium text-gray-700">委員会活動</span>
@@ -86,7 +86,7 @@ export default function SearchForm({ onSearch, onSearchTypeChange, loading = fal
               name="searchType"
               value="bills"
               checked={searchType === 'bills'}
-              onChange={(e) => handleSearchTypeChange(e.target.value as 'speeches' | 'committee_news' | 'bills' | 'questions' | 'manifestos')}
+              onChange={(e) => handleSearchTypeChange(e.target.value as 'speeches' | 'committee_news' | 'bills' | 'questions')}
               className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 focus:ring-2"
             />
             <span className="text-sm font-medium text-gray-700">提出法案</span>
@@ -97,21 +97,10 @@ export default function SearchForm({ onSearch, onSearchTypeChange, loading = fal
               name="searchType"
               value="questions"
               checked={searchType === 'questions'}
-              onChange={(e) => handleSearchTypeChange(e.target.value as 'speeches' | 'committee_news' | 'bills' | 'questions' | 'manifestos')}
+              onChange={(e) => handleSearchTypeChange(e.target.value as 'speeches' | 'committee_news' | 'bills' | 'questions')}
               className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 focus:ring-2"
             />
             <span className="text-sm font-medium text-gray-700">質問主意書</span>
-          </label>
-          <label className="flex items-center gap-2 cursor-pointer">
-            <input
-              type="radio"
-              name="searchType"
-              value="manifestos"
-              checked={searchType === 'manifestos'}
-              onChange={(e) => handleSearchTypeChange(e.target.value as 'speeches' | 'committee_news' | 'bills' | 'questions' | 'manifestos')}
-              className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 focus:ring-2"
-            />
-            <span className="text-sm font-medium text-gray-700">マニフェスト</span>
           </label>
         </div>
 
@@ -128,8 +117,7 @@ export default function SearchForm({ onSearch, onSearchTypeChange, loading = fal
               searchType === 'speeches' ? "議事録を検索（例：デジタル改革、社会保障制度、環境政策）" :
               searchType === 'committee_news' ? "委員会ニュースを検索（例：法案審議、委員会開催）" :
               searchType === 'bills' ? "提出法案を検索（例：デジタル庁設置法、環境基本法改正案）" :
-              searchType === 'questions' ? "質問主意書を検索（例：年金制度、外交政策、エネルギー問題）" :
-              "マニフェストを検索（例：経済政策、社会保障、外交・安保）"
+              "質問主意書を検索（例：年金制度、外交政策、エネルギー問題）"
             }
             className="search-input pl-10"
           />

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -20,7 +20,7 @@ export interface SearchParams {
   date_to?: string;
   limit?: number;
   offset?: number;
-  search_type?: 'speeches' | 'committee_news' | 'bills' | 'questions' | 'manifestos';
+  search_type?: 'speeches' | 'committee_news' | 'bills' | 'questions';
 }
 
 export interface SearchResult {


### PR DESCRIPTION
## Summary
- マニフェストを独立ページ(/manifestos)に分離し、議事録検索から削除
- 政党選択のみのシンプルなUIでマニフェスト検索を実装
- 議事録検索を4つの明確な検索タイプに整理（議事録、委員会活動、提出法案、質問主意書）

## Changes Made

### 🔄 マニフェスト独立ページ化
- `/app/manifestos/page.tsx` - 新規作成
- 政党選択ボタンによるフィルタリング機能
- 主要7政党対応（自民、立民、維新、公明、共産、国民、れいわ）
- レスポンシブ対応とアクセシビリティ配慮

### 🧹 議事録検索UI簡潔化
- `SearchForm.tsx` - マニフェスト選択肢を削除
- `types/index.ts` - SearchParams型からmanifestos除去
- `app/page.tsx` - マニフェスト関連のstate管理削除

### 🔗 ナビゲーション改善
- `Header.tsx` - マニフェストをSPAタブから独立ページリンクに変更
- 適切なNext.js Routerベースの画面遷移

## Technical Improvements
- TypeScriptエラー全解消
- 不要なstate管理ロジックの削除
- コンポーネント責任の明確化
- ビルド成功確認済み

## Test plan
- [x] `/manifestos`ページの動作確認
- [x] 政党フィルタリング機能テスト
- [x] 議事録検索の4タイプ動作確認
- [x] ナビゲーション遷移テスト
- [x] レスポンシブデザイン確認
- [x] TypeScriptビルドテスト

## Impact
- **UX向上**: より直感的で整理されたナビゲーション
- **保守性向上**: 機能分離による責任の明確化
- **パフォーマンス**: 不要な状態管理の削減

## Branch Management
- mainブランチから新規ブランチ `refactor/manifesto-separation-and-ui-cleanup` を作成
- 既存PR #73 の問題を解決し、適切なブランチ管理を実施
- 完全に独立したPRとして作成

🤖 Generated with [Claude Code](https://claude.ai/code)