### PR TITLE
fix: ヘッダー固定化とマニフェストページの統合改善

### DIFF
--- a/frontend/app/legislators/page.tsx
+++ b/frontend/app/legislators/page.tsx
@@ -57,7 +57,7 @@ export default function LegislatorsPage() {
   return (
     <div className="min-h-screen bg-gray-50">
       <Header currentPage="legislators" />
-      <main className="py-8">
+      <main className="py-8 pt-24">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* ヘッダー */}
         <div className="mb-8">

--- a/frontend/app/manifestos/page.tsx
+++ b/frontend/app/manifestos/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { Manifesto } from '@/types';
 import { dataLoader } from '@/lib/data-loader';
 import { Search, FileText, Users, Calendar, ExternalLink } from 'lucide-react';
+import Header from '@/components/Header';
 
 export default function ManifestosPage() {
   const [manifestos, setManifestos] = useState<Manifesto[]>([]);
@@ -88,7 +89,8 @@ export default function ManifestosPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <div className="container mx-auto px-4 py-8">
+      <Header currentPage="manifestos" />
+      <div className="container mx-auto px-4 py-8 pt-24">
         {/* ヘッダー */}
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-gray-900 mb-2">政党マニフェスト</h1>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -138,7 +138,7 @@ export default function Home() {
     <div className="min-h-screen bg-gray-50">
       <Header currentPage={currentPage} onPageChange={handlePageChange} />
       
-      <main>
+      <main className="pt-16">
         {currentPage === 'search' && (
           <div className="py-8">
             <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/frontend/app/summaries/page.tsx
+++ b/frontend/app/summaries/page.tsx
@@ -98,7 +98,7 @@ export default function SummariesPageWrapper() {
   return (
     <div className="min-h-screen bg-gray-50">
       <Header currentPage="summaries" />
-      <main>
+      <main className="pt-16">
         <SummariesPage
           initialSummaries={initialSummaries}
           houses={houses}

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -5,7 +5,7 @@ import { Search, BarChart3, Info, FileText, Users, Bot, Menu, X } from 'lucide-r
 import Link from 'next/link';
 
 interface HeaderProps {
-  currentPage?: 'search' | 'stats' | 'about' | 'legislators' | 'summaries';
+  currentPage?: 'search' | 'stats' | 'about' | 'legislators' | 'summaries' | 'manifestos';
   onPageChange?: (page: 'search' | 'stats' | 'about' | 'legislators') => void;
 }
 
@@ -29,7 +29,7 @@ export default function Header({ currentPage = 'search', onPageChange }: HeaderP
   };
 
   return (
-    <header className="bg-white shadow-sm border-b border-gray-200">
+    <header className="fixed top-0 left-0 right-0 z-50 bg-white shadow-sm border-b border-gray-200">
       <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">
           {/* ロゴ・タイトル */}


### PR DESCRIPTION
## Summary
- マニフェストページにHeaderコンポーネントを統合し、固定ヘッダーの実装を完了
- 全ページで一貫したナビゲーション体験を提供
- レスポンシブ対応の固定ヘッダーでUX向上

## 主な変更内容
### ヘッダー固定化
- `Header.tsx`: `fixed top-0 left-0 right-0 z-50` で固定ヘッダー実装
- 全ページで一貫したナビゲーションバーの表示

### マニフェストページ統合
- `manifestos/page.tsx`: 欠落していたHeaderコンポーネントを追加
- `HeaderProps`に`manifestos`ページタイプを追加

### レイアウト調整
- **メインページ**: `pt-16` でヘッダー高さ分のpadding追加
- **マニフェストページ**: `pt-24` でより適切な余白設定
- **議員一覧ページ**: `pt-24` で統一的なpadding
- **議会要約ページ**: `pt-16` で適切な余白設定

## 技術的改善
- TypeScript型定義の更新（HeaderPropsにmanifestosを追加）
- ビルド＆Lintテスト完了（エラーなし）
- レスポンシブ対応の固定ヘッダー

## Test plan
- [x] 全ページでヘッダーが固定表示されることを確認
- [x] マニフェストページでHeaderコンポーネントが正常に動作
- [x] 各ページで適切なpadding-topが適用されることを確認
- [x] モバイル・デスクトップ両方でのレスポンシブ動作確認
- [x] ナビゲーションリンクの動作確認
- [x] ビルド・Lintエラーがないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)